### PR TITLE
Docs/readme

### DIFF
--- a/configs/hardware-drivers/README.md
+++ b/configs/hardware-drivers/README.md
@@ -1,1 +1,0 @@
-This directory contains the configuration files for the drivers of the LLRS hardware components. The hardware drivers themselves are stored in the src-components/hardware-drivers directory


### PR DESCRIPTION
Merging the `README` branch as it's no longer needed, the documentation branch is now `docs/mdbook`.